### PR TITLE
Fix wrong console_scripts specification in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(name=NAME,
     ],
     entry_points={
         "console_scripts": [
-            "mpbn_sim=mpbn_sim.cli",
+            "mpbn_sim=mpbn_sim:cli",
         ],
     },
     packages=[NAME],


### PR DESCRIPTION
Hi,

There seems to be an issue with `console_scripts` in the `setup.py` file.
I had an error at installation with pip complaining about this:
```
ERROR: For req: mpbn-sim==0.1. Invalid script entry point: <ExportEntry mpbn_sim = mpbn_sim.cli:None []> - A callable suffix is required. Cf https://packaging.python.org/specifications/entry-points/#use-for-scripts for more information.
```

Looking at the docs it seems that it should be `mpbn_sim:cli` instead of `mpbn_sim.cli`, at least this works for me. Do you confirm that this also works on your side?